### PR TITLE
[add] Contact Support button to TOC

### DIFF
--- a/src/theme/TOCItems/index.js
+++ b/src/theme/TOCItems/index.js
@@ -1,0 +1,21 @@
+import TOCItems from '@theme-original/TOCItems';
+import styles from './styles.module.css';
+
+export default function TOCItemsWrapper(props) {
+  return (
+    <>
+      <TOCItems {...props} />
+      <div className={styles.contactSupportLinkWrapper}>
+        Need more help?
+        <a
+          href="https://dhtmlx.com/docs/technical-support.shtml"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${styles.contactSupportLink} pagination-nav__link`}
+        >
+          Contact Support
+        </a>
+      </div>
+    </>
+  );
+}

--- a/src/theme/TOCItems/styles.module.css
+++ b/src/theme/TOCItems/styles.module.css
@@ -1,0 +1,14 @@
+.contactSupportLinkWrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  align-items: start;
+  gap: 0.5rem;
+  margin: 1rem;
+}
+
+.contactSupportLink {
+  font-size: var(--ifm-h4-font-size);
+  font-weight: var(--ifm-heading-font-weight);
+  text-align: center;
+}


### PR DESCRIPTION
- swizzle TOCItems component to inject support link
- button appears below TOC on all pages with headings
- styles via CSS module using Infima design tokens