### PR TITLE
[update] add online examples link to React index

### DIFF
--- a/docs/react/index.md
+++ b/docs/react/index.md
@@ -12,6 +12,7 @@ The official declarative React wrapper for DHTMLX Spreadsheet. Build spreadsheet
 
 - [Installation](/react/installation/) - install the evaluation or commercial package
 - [Quick start](/react/quick-start/) - build your first spreadsheet app step by step
+- [Online examples](https://dhtmlx.com/react/demos/spreadsheet/) - check live demos of React Spreadsheet features
 
 :::info
 You can also explore the [GitHub demo repository](https://github.com/DHTMLX/react-spreadsheet-examples) for a complete working example.


### PR DESCRIPTION
- added link to live demos in the Get started section of react/index.md